### PR TITLE
oublish workflow shouldnt depend on pnpm lockfile

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,10 +23,9 @@ jobs:
         with:
           node-version: 20
           registry-url: 'https://npm.pkg.github.com'
-          cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Build packages
         run: pnpm run build --filter=@frame-bridge/*


### PR DESCRIPTION
* remove references to pnpm lockfile from the publish workflow
* allow the consuming application's package manager to resolve the dependency tree